### PR TITLE
Release/0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>zenodo-client</artifactId>
     <name>Zenodo client</name>
     <groupId>io.dockstore</groupId>
-    <version>0.2-SNAPSHOT</version>
+    <version>0.2</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -51,7 +51,7 @@
         <connection>${github.url}</connection>
         <developerConnection>${github.url}</developerConnection>
         <url>${github.url}</url>
-      <tag>HEAD</tag>
+      <tag>0.2</tag>
   </scm>
 
     <distributionManagement>
@@ -62,15 +62,6 @@
             <uniqueVersion>false</uniqueVersion>
         </repository>
     </distributionManagement>
-
-    <dependencies>
-        <dependency>
-            <groupId>net.sourceforge.cobertura</groupId>
-            <artifactId>cobertura</artifactId>
-            <version>2.1.1</version>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
 
     <dependencyManagement>
         <dependencies>
@@ -241,11 +232,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>cobertura-maven-plugin</artifactId>
-                    <version>2.7</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>
                     <version>3.0.4</version>
                 </plugin>
@@ -332,46 +318,10 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <configuration>
-                    <check />
-                    <formats>
-                        <format>xml</format>
-                        <format>html</format>
-                    </formats>
-                    <aggregate>true</aggregate>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>net.sourceforge.cobertura</groupId>
-                        <artifactId>cobertura</artifactId>
-                        <version>2.1.1</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-            <plugin>
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>
-
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <configuration>
-                    <check />
-                    <formats>
-                        <format>xml</format>
-                        <format>html</format>
-                    </formats>
-                    <aggregate>true</aggregate>
-                </configuration>
-            </plugin>
-        </plugins>
-    </reporting>
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>zenodo-client</artifactId>
     <name>Zenodo client</name>
     <groupId>io.dockstore</groupId>
-    <version>0.2</version>
+    <version>0.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -51,7 +51,7 @@
         <connection>${github.url}</connection>
         <developerConnection>${github.url}</developerConnection>
         <url>${github.url}</url>
-      <tag>0.2</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <distributionManagement>

--- a/zenodo-client-generated/pom.xml
+++ b/zenodo-client-generated/pom.xml
@@ -3,14 +3,21 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>zenodo-client-generated</artifactId>
-    <version>0.2-SNAPSHOT</version>
+    <version>0.2</version>
 
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>zenodo-client</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+    </licenses>
 
     <build>
         <plugins>
@@ -208,10 +215,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/zenodo-client-generated/pom.xml
+++ b/zenodo-client-generated/pom.xml
@@ -3,12 +3,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>zenodo-client-generated</artifactId>
-    <version>0.2</version>
+    <version>0.3-SNAPSHOT</version>
 
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>zenodo-client</artifactId>
-        <version>0.2</version>
+        <version>0.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/zenodo-client-tools/pom.xml
+++ b/zenodo-client-tools/pom.xml
@@ -3,12 +3,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>zenodo-client-tools</artifactId>
-    <version>0.2</version>
+    <version>0.3-SNAPSHOT</version>
 
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>zenodo-client</artifactId>
-        <version>0.2</version>
+        <version>0.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>zenodo-client-generated</artifactId>
-            <version>0.2</version>
+            <version>0.3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>

--- a/zenodo-client-tools/pom.xml
+++ b/zenodo-client-tools/pom.xml
@@ -3,14 +3,21 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>zenodo-client-tools</artifactId>
-    <version>0.2-SNAPSHOT</version>
+    <version>0.2</version>
 
     <parent>
         <groupId>io.dockstore</groupId>
         <artifactId>zenodo-client</artifactId>
-        <version>0.2-SNAPSHOT</version>
+        <version>0.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+    </licenses>
 
     <dependencies>
         <dependency>
@@ -21,7 +28,7 @@
         <dependency>
             <groupId>io.dockstore</groupId>
             <artifactId>zenodo-client-generated</artifactId>
-            <version>0.2-SNAPSHOT</version>
+            <version>0.2</version>
         </dependency>
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>


### PR DESCRIPTION
The project was failing to build because cobertura depended on com.sun:tools but jdk 11 no longer includes that, so I removed it from the project. Also added the license in the sub poms in case it's not picked up by what's in the parent.